### PR TITLE
add helper to create matcher from collection of matchers

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -1,0 +1,76 @@
+package its
+
+import "github.com/youta-t/its/itskit"
+
+// ForItems broadcasts matcherFactory for each elements, and wrap with s.
+//
+// This provides shorthands of Matchers using slice of Matchers.
+//
+// # Example
+//
+//	ForItems(Some, EqEq, []int{1, 2, 3, 4, 5})
+//
+// is, equiverent to
+//
+//	Some(
+//		EqEq(1), EqEq(2), EqEq(3), EqEq(4), EqEq(5),
+//	)
+//
+// # Args
+//
+// - s func(matchers []Matcher[T]) Matcher[X]: wraps matchers comes from matcherFactory
+//
+// - matcherFactory func(U) Matcher[T]: it applied for each items in wants to generate matchers for them
+//
+// - wants []U: values.
+func ForItems[T, U, X any, F func(U) Matcher[T], S func(...Matcher[T]) Matcher[X]](
+	s S, matcherFactory F, wants []U,
+) Matcher[X] {
+	cancel := itskit.SkipStack()
+	defer cancel()
+
+	ret := make([]Matcher[T], len(wants))
+	for i := range wants {
+		ret[i] = matcherFactory(wants[i])
+	}
+	return s(ret...)
+}
+
+// ForEntries broadcasts matcherFactory for each values in map, and wrap with s.
+//
+// This provides shordhands of Matchers using map of Matchers.
+//
+// # Example
+//
+//	ForEntries(Map, EqEq, map[string]int{"a": 1, "b": 2})
+//
+// is, equiverent to
+//
+//	Map(map[string]Matcher[int]{
+//		"a": its.EqEq(1), "b": its.EqEq(2)
+//	})
+//
+// # Args
+//
+// - s func(map[K]Matcher[T] Matcher[X]): wraps a map of matchers comes from matcherFactory
+//
+// - matcherFactory func(U)Matcher[T]: it applied for each values in enteies to generate map of Matchers.
+//
+// - wants: map entries.
+func ForEntries[
+	K comparable, T, U, X any, F func(U) Matcher[T], S func(map[K]Matcher[T]) Matcher[X],
+](
+	s S,
+	matcherFactory F,
+	wants map[K]U,
+) Matcher[X] {
+	cancel := itskit.SkipStack()
+	defer cancel()
+
+	m := map[K]Matcher[T]{}
+	for k := range wants {
+		m[k] = matcherFactory(wants[k])
+	}
+
+	return s(m)
+}

--- a/logical.go
+++ b/logical.go
@@ -8,7 +8,7 @@ import (
 // All tests actual passes all specs.
 //
 // If no matchers are given, it always pass.
-func All[T any](matchers ...Matcher[T]) itskit.Matcher[T] {
+func All[T any](matchers ...Matcher[T]) Matcher[T] {
 	cancel := itskit.SkipStack()
 	defer cancel()
 	return allMatcher[T]{
@@ -63,7 +63,7 @@ func (as allMatcher[T]) String() string {
 // All tests actual passes at least one spec.
 //
 // If no matchers are given, it always fail.
-func Some[T any](matchers ...Matcher[T]) itskit.Matcher[T] {
+func Some[T any](matchers ...Matcher[T]) Matcher[T] {
 	cancel := itskit.SkipStack()
 	defer cancel()
 	return someMatcher[T]{
@@ -120,7 +120,7 @@ type notMatcher[T any] struct {
 }
 
 // Inverts matcher.
-func Not[T any](matcher Matcher[T]) itskit.Matcher[T] {
+func Not[T any](matcher Matcher[T]) Matcher[T] {
 	cancel := itskit.SkipStack()
 	defer cancel()
 	return notMatcher[T]{
@@ -147,7 +147,7 @@ func (n notMatcher[T]) String() string {
 }
 
 // None tests got value does NOT match for all given matchers.
-func None[T any](matchers ...Matcher[T]) itskit.Matcher[T] {
+func None[T any](matchers ...Matcher[T]) Matcher[T] {
 	cancel := itskit.SkipStack()
 	defer cancel()
 	return noneMathcer[T]{

--- a/map_test.go
+++ b/map_test.go
@@ -4,109 +4,142 @@ import (
 	"github.com/youta-t/its"
 )
 
-func ExampleMap() {
-	its.Map(its.MapSpec[string, int]{
+func ExampleMap_ok() {
+	its.Map(map[string]its.Matcher[int]{
 		"a": its.EqEq(97),
 		"b": its.EqEq(98),
 		"c": its.EqEq(99),
-	}).Match(map[string]int{
+	}).
+		Match(map[string]int{
+			"a": 97,
+			"b": 98,
+			"c": 99,
+		}).
+		OrError(t)
+
+	// same as above
+	its.ForEntries(its.Map, its.EqEq, map[string]int{
 		"a": 97,
 		"b": 98,
 		"c": 99,
-	}).OrError(t)
-
-	its.Map(its.MapSpec[string, int]{
-		"a": its.EqEq(97),
-		"b": its.EqEq(98),
-		"c": its.EqEq(99),
-	}).Match(map[string]int{
-		"a": 97,
-		"b": 99,
-		"c": 99,
-	}).OrError(t)
-
-	its.Map(its.MapSpec[string, int]{
-		"a": its.EqEq(97),
-		"b": its.EqEq(98),
-		"c": its.EqEq(99),
-	}).Match(map[string]int{
-		"a": 97,
-		"b": 98,
-		"d": 99,
-	}).OrError(t)
+	}).
+		Match(map[string]int{
+			"a": 97,
+			"b": 98,
+			"c": 99,
+		}).
+		OrError(t)
 	// Output:
-	// ✘ map[string]int{... ( keys: /* got */ 3, /* want */ 3; +1, -1 )		--- @ ./map_test.go:18
+}
+
+func ExampleMap_different_value() {
+	its.ForEntries(its.Map, its.EqEq, map[string]int{
+		"a": 97,
+		"b": 98,
+		"c": 99,
+	}).
+		Match(map[string]int{
+			"a": 97,
+			"b": 99,
+			"c": 99,
+		}).
+		OrError(t)
+
+	// Output:
+	// ✘ map[string]int{... ( keys: /* got */ 3, /* want */ 3; +1, -1 )		--- @ ./map_test.go:36
 	//     ✔ a:
-	//         ✔ /* got */ 97 == /* want */ 97		--- @ ./map_test.go:19
+	//         ✔ /* got */ 97 == /* want */ 97		--- @ ./map_test.go:36
 	//     ✘ b:
-	//         ✘ /* got */ 99 == /* want */ 98		--- @ ./map_test.go:20
+	//         ✘ /* got */ 99 == /* want */ 98		--- @ ./map_test.go:36
 	//     ✔ c:
-	//         ✔ /* got */ 99 == /* want */ 99		--- @ ./map_test.go:21
-	//
-	// ✘ map[string]int{... ( keys: /* got */ 3, /* want */ 3; +1, -1 )		--- @ ./map_test.go:28
+	//         ✔ /* got */ 99 == /* want */ 99		--- @ ./map_test.go:36
+}
+
+func ExampleMap_different_key() {
+	its.ForEntries(its.Map, its.EqEq, map[string]int{
+		"a": 97,
+		"b": 98,
+		"c": 99,
+	}).
+		Match(map[string]int{
+			"a": 97,
+			"b": 98,
+			"d": 99,
+		}).
+		OrError(t)
+	// Output:
+	// ✘ map[string]int{... ( keys: /* got */ 3, /* want */ 3; +1, -1 )		--- @ ./map_test.go:59
 	//     ✔ a:
-	//         ✔ /* got */ 97 == /* want */ 97		--- @ ./map_test.go:29
+	//         ✔ /* got */ 97 == /* want */ 97		--- @ ./map_test.go:59
 	//     ✔ b:
-	//         ✔ /* got */ 98 == /* want */ 98		--- @ ./map_test.go:30
+	//         ✔ /* got */ 98 == /* want */ 98		--- @ ./map_test.go:59
 	//     ✘ c: (not in got)
-	//         ✘ /* got */ ?? == /* want */ 99		--- @ ./map_test.go:31
+	//         ✘ /* got */ ?? == /* want */ 99		--- @ ./map_test.go:59
 	//     ✘ d: (not in want)
 	//         ✘ /* got */ 99, /* want */ ??
 }
 
-func ExampleMapContaining() {
+func ExampleMapContaining_ok() {
 
-	its.MapContaining(its.MapSpec[string, int]{
+	its.MapContaining(map[string]its.Matcher[int]{
 		"a": its.EqEq(97),
 		"b": its.EqEq(98),
 		"c": its.EqEq(99),
-	}).Match(map[string]int{
+	}).
+		Match(map[string]int{
+			"a": 97,
+			"b": 98,
+			"c": 99,
+		}).
+		OrError(t)
+
+	// same above
+	its.ForEntries(its.MapContaining, its.EqEq, map[string]int{
 		"a": 97,
 		"b": 98,
 		"c": 99,
-	}).OrError(t)
+	}).
+		Match(map[string]int{
+			"a": 97,
+			"b": 98,
+			"c": 99,
+		}).
+		OrError(t)
 
-	its.MapContaining(its.MapSpec[string, int]{
-		"a": its.EqEq(97),
-		"c": its.EqEq(99),
-	}).Match(map[string]int{
-		"a": 97,
-		"b": 98,
-		"c": 99,
-	}).OrError(t)
-
-	its.MapContaining(its.MapSpec[string, int]{
-		"a": its.EqEq(96),
-		"c": its.EqEq(99),
-	}).Match(map[string]int{
-		"a": 97,
-		"b": 98,
-		"c": 99,
-	}).OrError(t)
-
-	its.MapContaining(its.MapSpec[string, int]{
-		"a": its.EqEq(97),
-		"b": its.EqEq(98),
-		"c": its.EqEq(99),
-	}).Match(map[string]int{
+	// less entries is ok.
+	its.ForEntries(its.MapContaining, its.EqEq, map[string]int{
 		"a": 97,
 		"c": 99,
-	}).OrError(t)
-
+	}).
+		Match(map[string]int{
+			"a": 97,
+			"b": 98,
+			"c": 99,
+		}).
+		OrError(t)
 	// Output:
-	// ✘ map[string]int{ ... (contain; keys /* got */ 3, /* want */ 2; -1)		--- @ ./map_test.go:78
+}
+
+func ExampleMapContaining_different_entries() {
+	its.ForEntries(its.MapContaining, its.EqEq, map[string]int{
+		"a": 96,
+		"b": 98,
+		"d": 99,
+	}).
+		Match(map[string]int{
+			"a": 97,
+			"b": 98,
+			"c": 99,
+		}).
+		OrError(t)
+	// Output:
+	// ✘ map[string]int{ ... (contain; keys /* got */ 3, /* want */ 3; -2)		--- @ ./map_test.go:124
 	//     ✘ a:
-	//         ✘ /* got */ 97 == /* want */ 96		--- @ ./map_test.go:79
-	//     ✘ b: (not in want)
-	//         ✘ /* got */ 98, /* want */ ??
-	//     ✔ c:
-	//         ✔ /* got */ 99 == /* want */ 99		--- @ ./map_test.go:80
-	//
-	// ✘ map[string]int{ ... (contain; keys /* got */ 2, /* want */ 3; -1)		--- @ ./map_test.go:87
-	//     ✔ a:
-	//         ✔ /* got */ 97 == /* want */ 97		--- @ ./map_test.go:88
-	//     ✘ b: (not in got)
-	//         ✘ /* got */ ?? == /* want */ 98		--- @ ./map_test.go:89
-	//     ✔ c:
-	//         ✔ /* got */ 99 == /* want */ 99		--- @ ./map_test.go:90
+	//         ✘ /* got */ 97 == /* want */ 96		--- @ ./map_test.go:124
+	//     ✔ b:
+	//         ✔ /* got */ 98 == /* want */ 98		--- @ ./map_test.go:124
+	//     ✘ c: (not in want)
+	//         ✘ /* got */ 99, /* want */ ??
+	//     ✘ d: (not in got)
+	//         ✘ /* got */ ?? == /* want */ 99		--- @ ./map_test.go:124
 }

--- a/slice_test.go
+++ b/slice_test.go
@@ -4,35 +4,71 @@ import (
 	"github.com/youta-t/its"
 )
 
-func ExampleSlice() {
+func ExampleSlice_ok() {
 	// pass
-	its.Slice(
-		its.EqEq(1), its.EqEq(2), its.EqEq(3),
-	).Match(
-		[]int{1, 2, 3},
-	).OrError(t)
+	its.Slice(its.EqEq(1), its.EqEq(2), its.EqEq(3)).
+		Match([]int{1, 2, 3}).
+		OrError(t)
 
+	// it is same thing as above
+	its.ForItems(its.Slice, its.EqEq, []int{1, 2, 3}).
+		Match([]int{1, 2, 3}).
+		OrError(t)
+
+	// Output:
+}
+
+func ExampleSlice_different_order() {
 	// fail. Order is matter.
-	its.Slice(
-		its.EqEq(2), its.EqEq(1), its.EqEq(3),
-	).Match(
-		[]int{1, 2, 3},
-	).OrError(t)
+	its.Slice(its.EqEq(2), its.EqEq(1), its.EqEq(3)).
+		Match([]int{1, 2, 3}).
+		OrError(t)
 
+	// same as above
+	its.ForItems(its.Slice, its.EqEq, []int{2, 1, 3}).
+		Match([]int{1, 2, 3}).
+		OrError(t)
+
+	// Output:
+	// ✘ []int{ ... (len: /* got */ 3, /* want */ 3; +1, -1)		--- @ ./slice_test.go:23
+	//     ✘ - /* got */ ?? == /* want */ 2		--- @ ./slice_test.go:23
+	//     ✔ /* got */ 1 == /* want */ 1		--- @ ./slice_test.go:23
+	//     ✘ + /* got */ 2
+	//     ✔ /* got */ 3 == /* want */ 3		--- @ ./slice_test.go:23
+	//
+	// ✘ []int{ ... (len: /* got */ 3, /* want */ 3; +1, -1)		--- @ ./slice_test.go:28
+	//     ✘ - /* got */ ?? == /* want */ 2		--- @ ./slice_test.go:28
+	//     ✔ /* got */ 1 == /* want */ 1		--- @ ./slice_test.go:28
+	//     ✘ + /* got */ 2
+	//     ✔ /* got */ 3 == /* want */ 3		--- @ ./slice_test.go:28
+}
+
+func ExampleSlice_different_length() {
 	// fail. Actual has not enough 3.
-	its.Slice(
-		its.EqEq(1), its.EqEq(2), its.EqEq(3), its.EqEq(3),
-	).Match(
-		[]int{1, 2, 3},
-	).OrError(t)
+	its.ForItems(its.Slice, its.EqEq, []int{1, 2, 3, 3}).
+		Match([]int{1, 2, 3}).
+		OrError(t)
 
 	// fail. Actual has too much 3.
-	its.Slice(
-		its.EqEq(1), its.EqEq(2), its.EqEq(3),
-	).Match(
-		[]int{1, 2, 3, 3},
-	).OrError(t)
+	its.ForItems(its.Slice, its.EqEq, []int{1, 2, 3}).
+		Match([]int{1, 2, 3, 3}).
+		OrError(t)
 
+	// Output:
+	// ✘ []int{ ... (len: /* got */ 3, /* want */ 4; +0, -1)		--- @ ./slice_test.go:48
+	//     ✔ /* got */ 1 == /* want */ 1		--- @ ./slice_test.go:48
+	//     ✔ /* got */ 2 == /* want */ 2		--- @ ./slice_test.go:48
+	//     ✔ /* got */ 3 == /* want */ 3		--- @ ./slice_test.go:48
+	//     ✘ - /* got */ ?? == /* want */ 3		--- @ ./slice_test.go:48
+	//
+	// ✘ []int{ ... (len: /* got */ 4, /* want */ 3; +1, -0)		--- @ ./slice_test.go:53
+	//     ✔ /* got */ 1 == /* want */ 1		--- @ ./slice_test.go:53
+	//     ✔ /* got */ 2 == /* want */ 2		--- @ ./slice_test.go:53
+	//     ✔ /* got */ 3 == /* want */ 3		--- @ ./slice_test.go:53
+	//     ✘ + /* got */ 3
+}
+
+func ExampleSlice_empty() {
 	// pass. its empty.
 	its.Slice[int]().Match([]int{}).OrError(t)
 
@@ -43,60 +79,62 @@ func ExampleSlice() {
 	its.Slice[int]().Match([]int{1}).OrError(t)
 
 	// Output:
-	// ✘ []int{ ... (len: /* got */ 3, /* want */ 3; +1, -1)		--- @ ./slice_test.go:16
-	//     ✘ - /* got */ ?? == /* want */ 2		--- @ ./slice_test.go:17
-	//     ✔ /* got */ 1 == /* want */ 1		--- @ ./slice_test.go:17
-	//     ✘ + /* got */ 2
-	//     ✔ /* got */ 3 == /* want */ 3		--- @ ./slice_test.go:17
+	// ✘ []int{ ... (len: /* got */ 0, /* want */ 1; +0, -1)		--- @ ./slice_test.go:76
+	//     ✘ - /* got */ ?? == /* want */ 1		--- @ ./slice_test.go:76
 	//
-	// ✘ []int{ ... (len: /* got */ 3, /* want */ 4; +0, -1)		--- @ ./slice_test.go:23
-	//     ✔ /* got */ 1 == /* want */ 1		--- @ ./slice_test.go:24
-	//     ✔ /* got */ 2 == /* want */ 2		--- @ ./slice_test.go:24
-	//     ✔ /* got */ 3 == /* want */ 3		--- @ ./slice_test.go:24
-	//     ✘ - /* got */ ?? == /* want */ 3		--- @ ./slice_test.go:24
-	//
-	// ✘ []int{ ... (len: /* got */ 4, /* want */ 3; +1, -0)		--- @ ./slice_test.go:30
-	//     ✔ /* got */ 1 == /* want */ 1		--- @ ./slice_test.go:31
-	//     ✔ /* got */ 2 == /* want */ 2		--- @ ./slice_test.go:31
-	//     ✔ /* got */ 3 == /* want */ 3		--- @ ./slice_test.go:31
-	//     ✘ + /* got */ 3
-	//
-	// ✘ []int{ ... (len: /* got */ 0, /* want */ 1; +0, -1)		--- @ ./slice_test.go:40
-	//     ✘ - /* got */ ?? == /* want */ 1		--- @ ./slice_test.go:40
-	//
-	// ✘ []int{ ... (len: /* got */ 1, /* want */ 0; +1, -0)		--- @ ./slice_test.go:43
+	// ✘ []int{ ... (len: /* got */ 1, /* want */ 0; +1, -0)		--- @ ./slice_test.go:79
 	//     ✘ + /* got */ 1
 }
 
-func ExampleSliceUnordered() {
+func ExampleSliceUnordered_ok() {
 	// pass
-	its.SliceUnordered(
-		its.EqEq(1), its.EqEq(2), its.EqEq(3),
-	).Match(
-		[]int{1, 2, 3},
-	).OrError(t)
+	its.SliceUnordered(its.EqEq(1), its.EqEq(2), its.EqEq(3)).
+		Match([]int{1, 2, 3}).
+		OrError(t)
+
+	// same as above
+	its.ForItems(its.SliceUnordered, its.EqEq, []int{1, 2, 3}).
+		Match([]int{1, 2, 3}).
+		OrError(t)
 
 	// pass. order is not matter.
-	its.SliceUnordered(
-		its.EqEq(1), its.EqEq(2), its.EqEq(3),
-	).Match(
-		[]int{3, 1, 2},
-	).OrError(t)
+	its.SliceUnordered(its.EqEq(1), its.EqEq(2), its.EqEq(3)).
+		Match([]int{3, 1, 2}).
+		OrError(t)
 
+	// same as above
+	its.ForItems(its.SliceUnordered, its.EqEq, []int{1, 2, 3}).
+		Match([]int{3, 1, 2}).
+		OrError(t)
+
+	// Output:
+}
+
+func ExampleSliceUnordered_different_length() {
 	// fail. there is an extra item 42.
-	its.SliceUnordered(
-		its.EqEq(1), its.EqEq(2), its.EqEq(3),
-	).Match(
-		[]int{1, 2, 3, 42},
-	).OrError(t)
+	its.ForItems(its.SliceUnordered, its.EqEq, []int{1, 2, 3}).
+		Match([]int{1, 2, 3, 3}).
+		OrError(t)
 
 	// fail. 3 is missing.
-	its.SliceUnordered(
-		its.EqEq(1), its.EqEq(2), its.EqEq(3),
-	).Match(
-		[]int{1, 2},
-	).OrError(t)
+	its.ForItems(its.SliceUnordered, its.EqEq, []int{1, 2, 3}).
+		Match([]int{1, 2}).
+		OrError(t)
 
+	// Output:
+	// ✘ []int{ ... (unordered; len: /* want */ 3, /* got */ 4; +1, -0)		--- @ ./slice_test.go:115
+	//     ✔ /* got */ 1 == /* want */ 1		--- @ ./slice_test.go:115
+	//     ✔ /* got */ 2 == /* want */ 2		--- @ ./slice_test.go:115
+	//     ✔ /* got */ 3 == /* want */ 3		--- @ ./slice_test.go:115
+	//     ✘ + /* got */ 3
+	//
+	// ✘ []int{ ... (unordered; len: /* want */ 3, /* got */ 2; +0, -1)		--- @ ./slice_test.go:120
+	//     ✔ /* got */ 1 == /* want */ 1		--- @ ./slice_test.go:120
+	//     ✔ /* got */ 2 == /* want */ 2		--- @ ./slice_test.go:120
+	//     ✘ - /* got */ ?? == /* want */ 3		--- @ ./slice_test.go:120
+}
+
+func ExampleSliceUnordered_empty() {
 	// pass. its empty.
 	its.SliceUnordered[int]().Match([]int{}).OrError(t)
 
@@ -105,54 +143,63 @@ func ExampleSliceUnordered() {
 
 	// fail. its empty.
 	its.SliceUnordered[int]().Match([]int{1}).OrError(t)
+
 	// Output:
-	// ✘ []int{ ... (unordered; len: /* want */ 3, /* got */ 4; +1, -0)		--- @ ./slice_test.go:87
-	//     ✔ /* got */ 1 == /* want */ 1		--- @ ./slice_test.go:88
-	//     ✔ /* got */ 2 == /* want */ 2		--- @ ./slice_test.go:88
-	//     ✔ /* got */ 3 == /* want */ 3		--- @ ./slice_test.go:88
-	//     ✘ + /* got */ 42
+	// ✘ []int{ ... (unordered; len: /* want */ 1, /* got */ 0; +0, -1)		--- @ ./slice_test.go:142
+	//     ✘ - /* got */ ?? == /* want */ 1		--- @ ./slice_test.go:142
 	//
-	// ✘ []int{ ... (unordered; len: /* want */ 3, /* got */ 2; +0, -1)		--- @ ./slice_test.go:94
-	//     ✔ /* got */ 1 == /* want */ 1		--- @ ./slice_test.go:95
-	//     ✔ /* got */ 2 == /* want */ 2		--- @ ./slice_test.go:95
-	//     ✘ - /* got */ ?? == /* want */ 3		--- @ ./slice_test.go:95
-	//
-	// ✘ []int{ ... (unordered; len: /* want */ 1, /* got */ 0; +0, -1)		--- @ ./slice_test.go:104
-	//     ✘ - /* got */ ?? == /* want */ 1		--- @ ./slice_test.go:104
-	//
-	// ✘ []int{ ... (unordered; len: /* want */ 0, /* got */ 1; +1, -0)		--- @ ./slice_test.go:107
+	// ✘ []int{ ... (unordered; len: /* want */ 0, /* got */ 1; +1, -0)		--- @ ./slice_test.go:145
 	//     ✘ + /* got */ 1
 }
 
-func ExampleSliceUnorderedContaining() {
+func ExampleSliceUnorderedContaining_ok() {
 	// pass
-	its.SliceUnorderedContaining(
-		its.EqEq(1), its.EqEq(2), its.EqEq(3),
-	).Match(
-		[]int{1, 2, 3},
-	).OrError(t)
+	its.SliceUnorderedContaining(its.EqEq(1), its.EqEq(2), its.EqEq(3)).
+		Match([]int{1, 2, 3}).
+		OrError(t)
+
+	// same as above
+	its.ForItems(its.SliceUnorderedContaining, its.EqEq, []int{1, 2, 3}).
+		Match([]int{1, 2, 3}).
+		OrError(t)
 
 	// pass. order is not matter.
-	its.SliceUnorderedContaining(
-		its.EqEq(1), its.EqEq(2), its.EqEq(3),
-	).Match(
-		[]int{3, 1, 2},
-	).OrError(t)
+	its.SliceUnorderedContaining(its.EqEq(1), its.EqEq(2), its.EqEq(3)).
+		Match([]int{3, 1, 2}).
+		OrError(t)
+
+	// same as above
+	its.ForItems(its.SliceUnorderedContaining, its.EqEq, []int{1, 2, 3}).
+		Match([]int{3, 1, 2}).
+		OrError(t)
 
 	// pass. extra item is okay.
-	its.SliceUnorderedContaining(
-		its.EqEq(1), its.EqEq(2), its.EqEq(3),
-	).Match(
-		[]int{1, 2, 3, 42},
-	).OrError(t)
+	its.SliceUnorderedContaining(its.EqEq(1), its.EqEq(2), its.EqEq(3)).
+		Match([]int{1, 2, 3, 3}).
+		OrError(t)
 
+	// same as above
+	its.ForItems(its.SliceUnorderedContaining, its.EqEq, []int{1, 2, 3}).
+		Match([]int{1, 2, 3, 3}).
+		OrError(t)
+
+	// Ouptut:
+}
+
+func ExampleSliceUnorderedContaining_missing_item() {
 	// fail. 3 is missing.
-	its.SliceUnorderedContaining(
-		its.EqEq(1), its.EqEq(2), its.EqEq(3),
-	).Match(
-		[]int{1, 2},
-	).OrError(t)
+	its.ForItems(its.SliceUnorderedContaining, its.EqEq, []int{1, 2, 3}).
+		Match([]int{1, 2}).
+		OrError(t)
 
+	// Output:
+	// ✘ []int{ ... (unordered, contain; len: /* got */ 2, /* want */ 3; -1)		--- @ ./slice_test.go:191
+	//     ✔ /* got */ 1 == /* want */ 1		--- @ ./slice_test.go:191
+	//     ✔ /* got */ 2 == /* want */ 2		--- @ ./slice_test.go:191
+	//     ✘ - /* got */ ?? == /* want */ 3		--- @ ./slice_test.go:191
+}
+
+func ExampleSliceUnorderedContaining_empty() {
 	// pass. its empty.
 	its.SliceUnorderedContaining[int]().Match([]int{}).OrError(t)
 
@@ -163,11 +210,6 @@ func ExampleSliceUnorderedContaining() {
 	its.SliceUnorderedContaining[int]().Match([]int{1}).OrError(t)
 
 	// Output:
-	// ✘ []int{ ... (unordered, contain; len: /* got */ 2, /* want */ 3; -1)		--- @ ./slice_test.go:150
-	//     ✔ /* got */ 1 == /* want */ 1		--- @ ./slice_test.go:151
-	//     ✔ /* got */ 2 == /* want */ 2		--- @ ./slice_test.go:151
-	//     ✘ - /* got */ ?? == /* want */ 3		--- @ ./slice_test.go:151
-	//
-	// ✘ []int{ ... (unordered, contain; len: /* got */ 0, /* want */ 1; -1)		--- @ ./slice_test.go:160
-	//     ✘ - /* got */ ?? == /* want */ 1		--- @ ./slice_test.go:160
+	// ✘ []int{ ... (unordered, contain; len: /* got */ 0, /* want */ 1; -1)		--- @ ./slice_test.go:207
+	//     ✘ - /* got */ ?? == /* want */ 1		--- @ ./slice_test.go:207
 }


### PR DESCRIPTION
This PR adds 2 helper functions

- `its.ForItems` : helps to create `Matcher` from slice of `Matcher` s
- `its.ForEntries` : helps to create `Matcher` from map of `Matcher` s

This PR

- closes #5 