### PR TITLE
`ClosedChan` is acceptable `chan T` and `<-chan T`

### DIFF
--- a/general.go
+++ b/general.go
@@ -371,22 +371,22 @@ func Inf() Matcher[float64] {
 	)
 }
 
-type chanMatcher[T any] struct {
+type chanMatcher[T any, C chan T | <-chan T] struct {
 	label itskit.Label
 }
 
 // ClosedChan tests wheather channel is closed or not.
 //
 // This matcher tries to receive from channel, it may cause sideeffect.
-func ClosedChan[T any]() Matcher[<-chan T] {
+func ClosedChan[C chan T | <-chan T, T any]() Matcher[C] {
 	cancel := itskit.SkipStack()
 	defer cancel()
-	return chanMatcher[T]{
+	return chanMatcher[T, C]{
 		label: itskit.NewLabelWithLocation("chan %T is %s.", *new(T), itskit.Placeholder),
 	}
 }
 
-func (c chanMatcher[T]) Match(ch <-chan T) itskit.Match {
+func (c chanMatcher[T, C]) Match(ch C) itskit.Match {
 	var closed bool
 	select {
 	case _, ok := <-ch:
@@ -405,12 +405,12 @@ func (c chanMatcher[T]) Match(ch <-chan T) itskit.Match {
 	)
 }
 
-func (c chanMatcher[T]) Write(ww itsio.Writer) error {
+func (c chanMatcher[T, C]) Write(ww itsio.Writer) error {
 	return c.label.Write(ww)
 }
 
-func (c chanMatcher[T]) String() string {
-	return itskit.MatcherToString[<-chan T](c)
+func (c chanMatcher[T, C]) String() string {
+	return itskit.MatcherToString(c)
 }
 
 // Type tests got value is a type.

--- a/general_test.go
+++ b/general_test.go
@@ -399,12 +399,12 @@ func ExampleInf_ng() {
 func ExampleClosedChan_ok() {
 	ch1 := make(chan int, 1)
 	close(ch1)
-	its.ClosedChan[int]().Match(ch1).OrError(t)
+	its.ClosedChan[chan int]().Match(ch1).OrError(t)
 	// Output:
 }
 func ExampleClosedChan_ng() {
 	ch2 := make(chan string, 1)
-	its.ClosedChan[string]().Match(ch2).OrError(t)
+	its.ClosedChan[chan string]().Match(ch2).OrError(t)
 	// Output:
 	// ✘ chan string is not closed.		--- @ ./general_test.go:407
 }

--- a/mocker/internal/types_test/gen_mock/type_interfaces.go
+++ b/mocker/internal/types_test/gen_mock/type_interfaces.go
@@ -4,8 +4,8 @@ package gen_mock
 import (
 	its "github.com/youta-t/its"
 	itskit "github.com/youta-t/its/itskit"
-	u_sub "github.com/youta-t/its/mocker/internal/example/sub"
 	testee "github.com/youta-t/its/mocker/internal/types_test"
+	u_sub "github.com/youta-t/its/mocker/internal/example/sub"
 	
 )
 


### PR DESCRIPTION
Kind of `ClosedChan` is changed from `[T any]` to `[C chan T|<-chan T, T any]`