### PR TITLE
mocker and structer generates better code for external modules

### DIFF
--- a/internal/parser/context.go
+++ b/internal/parser/context.go
@@ -95,18 +95,26 @@ func (pc *parseContext) detectSourceDir(importPath string) (importTarget, error)
 
 	importPathSlash := importPath + "/"
 
-	for module, dir := range pc.require {
-		m := module + "/"
-		if !strings.HasPrefix(importPathSlash, m) {
+	module := ""
+	dir := ""
+	for mod, d := range pc.require {
+		if !strings.HasPrefix(importPathSlash, mod+"/") {
 			continue
 		}
-		rel := filepath.FromSlash(importPath[len(m):])
-		targ.Dir = filepath.Join(dir, rel)
-
-		return targ, nil
+		if len(mod) <= len(module) {
+			continue
+		}
+		module = mod
+		rel := filepath.FromSlash(importPath[len(mod):])
+		dir = filepath.Join(d, rel)
 	}
 
-	targ.Dir = filepath.Join(pc.stdDir, filepath.FromSlash(importPath))
+	if len(module) != 0 {
+		targ.Dir = dir
+	} else {
+		targ.Dir = filepath.Join(pc.stdDir, filepath.FromSlash(importPath))
+	}
+
 	return targ, nil
 }
 

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -26,7 +26,7 @@ func parsePackage(bc ParseContext, pkg importTarget) (*Package, error) {
 		},
 	}
 
-	bpkg, err := build.ImportDir(pkg.Dir, 0)
+	bpkg, err := build.Import(pkg.ImportPath, ".", 0)
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +128,8 @@ func parseFile(bc ParseContext, pkg importTarget, filename string) (*TypeDeclara
 		case ".":
 			dot, err := bc.Import(p)
 			if err != nil {
-				return nil, err
+				// return nil, err
+				continue
 			}
 			for _, decl := range dot.Types.Structs.Slice() {
 				types[decl.Name] = &NamedType{ImportPath: p, Name: decl.Name}
@@ -146,7 +147,8 @@ func parseFile(bc ParseContext, pkg importTarget, filename string) (*TypeDeclara
 		case "":
 			imported, err := bc.Import(p)
 			if err != nil {
-				return nil, err
+				// return nil, err
+				continue
 			}
 			n = imported.DefaultName
 		}
@@ -477,6 +479,9 @@ func parseStruct(imports []ImportStatment, snode *ast.StructType) *StructType {
 
 		if 0 < len(f.Names) {
 			for _, n := range f.Names {
+				if isPrivateName(n.Name) {
+					continue
+				}
 				fields = append(fields, &Field{Name: n.Name, Type: typ})
 			}
 		} else {

--- a/mocker/main.go
+++ b/mocker/main.go
@@ -83,8 +83,6 @@ It generates a file with same name as a file having go:generate directive.
 		log.Fatalf("-source is required")
 		flag.Usage()
 		return
-	} else {
-		source = try.To(filepath.Abs(source)).OrFatal(logger)
 	}
 	if dest == "" {
 		log.Fatalf("-dest is required")
@@ -100,7 +98,8 @@ It generates a file with same name as a file having go:generate directive.
 	if *sourceAsPackage {
 		pkg = try.To(parserInstance.Import(source)).OrFatal(logger)
 	} else {
-		dir, _ := filepath.Split(source)
+		source = try.To(filepath.Abs(source)).OrFatal(logger)
+		dir := filepath.Dir(source)
 		targetFile = source
 		pkg = try.To(parserInstance.ImportDir(dir)).OrFatal(logger)
 	}
@@ -194,6 +193,7 @@ It generates a file with same name as a file having go:generate directive.
 
 			newFile.Interfaces = append(newFile.Interfaces, s)
 			types := s.Require()
+			newFile.Imports.Add(s.ImportPath)
 			for i := range types {
 				t := types[i]
 				newFile.Imports.Add(t)

--- a/structer/main.go
+++ b/structer/main.go
@@ -83,8 +83,6 @@ The new file, has "Matcher" and "Spec" types, is placed in "./gen_structer" dire
 		log.Fatalf("-source is required")
 		flag.Usage()
 		return
-	} else {
-		source = try.To(filepath.Abs(source)).OrFatal(logger)
 	}
 	if dest == "" {
 		log.Fatalf("-dest is required")
@@ -100,6 +98,7 @@ The new file, has "Matcher" and "Spec" types, is placed in "./gen_structer" dire
 	if *sourceAsPackage {
 		pkg = try.To(parserInstance.Import(source)).OrFatal(logger)
 	} else {
+		source = try.To(filepath.Abs(source)).OrFatal(logger)
 		dir := filepath.Dir(source)
 		targetFile = source
 		pkg = try.To(parserInstance.ImportDir(dir)).OrFatal(logger)


### PR DESCRIPTION
- structer:
    - skip transitive imports which are not used by generated mock
- mocker:
    - output package name of return value of `*_Build` funcs.
- both:
    - use longest match for import path and required package pairing.
    - fix `-as-package` flag
