### PR TITLE
add `context.Context` related Matchers

### DIFF
--- a/context.go
+++ b/context.go
@@ -1,0 +1,16 @@
+package its
+
+import (
+	"context"
+
+	"github.com/youta-t/its/itskit"
+)
+
+// Context is alias of `its.Always[context.Context]()`
+func Context() Matcher[context.Context] {
+	// define as func not to be replaced.
+	cancel := itskit.SkipStack()
+	defer cancel()
+
+	return Always[context.Context]()
+}

--- a/context_test.go
+++ b/context_test.go
@@ -1,0 +1,40 @@
+package its_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/youta-t/its"
+)
+
+func ExampleContext() {
+	ctx := context.Background()
+	todo := context.TODO()
+
+	withCancel, cancel1 := context.WithCancel(ctx)
+	defer cancel1()
+	withoutCancel := context.WithoutCancel(withCancel)
+
+	withDeadline, cancel2 := context.WithDeadline(ctx, time.Now().Add(-1*time.Second))
+	defer cancel2()
+
+	withTimeout, cancel3 := context.WithTimeout(ctx, 0*time.Second)
+	defer cancel3()
+
+	type key string
+	var k key = "key"
+	withValue := context.WithValue(ctx, k, "value")
+
+	var nilContext context.Context = nil
+
+	its.Context().Match(ctx).OrError(t)
+	its.Context().Match(todo).OrError(t)
+	its.Context().Match(withCancel).OrError(t)
+	its.Context().Match(withoutCancel).OrError(t)
+	its.Context().Match(withDeadline).OrError(t)
+	its.Context().Match(withTimeout).OrError(t)
+	its.Context().Match(withValue).OrError(t)
+	its.Context().Match(nilContext).OrError(t)
+
+	// Output:
+}

--- a/context_with_value.go
+++ b/context_with_value.go
@@ -1,0 +1,96 @@
+package its
+
+import (
+	"context"
+
+	"github.com/youta-t/its/itskit"
+	"github.com/youta-t/its/itskit/itsio"
+)
+
+type contextWithValueMatcher[T any] struct {
+	label    itskit.Label
+	nilLabel string
+	key      any
+	base     Matcher[T]
+}
+
+func (m *contextWithValueMatcher[T]) Match(ctx context.Context) itskit.Match {
+	if ctx == nil {
+		return itskit.NG(m.nilLabel)
+	}
+
+	got := ctx.Value(m.key)
+	switch gott := got.(type) {
+	case T:
+		match := m.base.Match(gott)
+		return itskit.NewMatch(
+			match.Ok(),
+			m.label.Fill(gott),
+			match,
+		)
+	case any: // type mismatch
+		return itskit.NG(
+			m.label.Fill(got),
+			itskit.NG(
+				itskit.NewLabel("%+v is not %T", itskit.Got, *new(T)).Fill(got),
+			),
+		)
+	default: // untyped!
+		if mm, ok := m.base.(Matcher[any]); ok {
+			match := mm.Match(gott)
+			return itskit.NewMatch(
+				match.Ok(),
+				m.label.Fill(gott),
+				match,
+			)
+		}
+		return itskit.NG(
+			m.label.Fill(got),
+			itskit.NG(
+				itskit.NewLabel("%+v is not %T", itskit.Got, *new(T)).Fill(got),
+			),
+		)
+	}
+
+}
+
+func (m *contextWithValueMatcher[T]) Write(ww itsio.Writer) error {
+	if err := m.label.Write(ww); err != nil {
+		return err
+	}
+	in := ww.Indent()
+	if err := m.base.Write(in); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *contextWithValueMatcher[T]) String() string {
+	return itskit.MatcherToString(m)
+}
+
+// ContextWithValue tests with
+//
+//	value.Match(ctx.Value(key))
+//
+// If the value is not type T, the match will fail.
+//
+// # Args
+//
+// - key: key associated with Value
+//
+// - value: the matcher for Value typed T
+func ContextWithValue[T any](key any, value Matcher[T]) Matcher[context.Context] {
+	cancel := itskit.SkipStack()
+	defer cancel()
+
+	return &contextWithValueMatcher[T]{
+		label: itskit.NewLabelWithLocation(
+			"// got = ctx.Value(%+v)",
+			key,
+		),
+		nilLabel: itskit.NewLabelWithLocation("// given context.Context is nil").Fill(nil),
+		key:      key,
+		base:     value,
+	}
+}

--- a/context_with_value_test.go
+++ b/context_with_value_test.go
@@ -1,0 +1,88 @@
+package its_test
+
+import (
+	"context"
+
+	"github.com/youta-t/its"
+)
+
+func ExampleContextWithValue_ok() {
+	ctx := context.Background()
+
+	type key string
+	var k1 key = "key 1"
+	var v1 string = "value 1"
+
+	var k2 key = "key 2"
+	var v2 int = 42
+
+	var k3 key = "key 3"
+
+	ctx = context.WithValue(ctx, k1, v1)
+	ctx = context.WithValue(ctx, k2, v2)
+
+	its.ContextWithValue(k1, its.EqEq("value 1")).Match(ctx).OrError(t)
+	its.ContextWithValue(k2, its.EqEq(42)).Match(ctx).OrError(t)
+	its.ContextWithValue(k3, its.Nil[any]()).Match(ctx).OrError(t)
+
+	// Output:
+}
+
+func ExampleContextWithValue_ng_by_value() {
+	ctx := context.Background()
+
+	type key string
+	var k1 key = "key 1"
+	var v1 string = "value 1"
+
+	var k2 key = "key 2"
+	var v2 int = 42
+
+	ctx = context.WithValue(ctx, k1, v1)
+	ctx = context.WithValue(ctx, k2, v2)
+
+	its.ContextWithValue(k1, its.EqEq("value 2")).Match(ctx).OrError(t)
+	its.ContextWithValue(k2, its.EqEq(43)).Match(ctx).OrError(t)
+
+	// Output:
+	// ✘ // got = ctx.Value(key 1)		--- @ ./context_with_value_test.go:44
+	//     ✘ /* got */ value 1 == /* want */ value 2		--- @ ./context_with_value_test.go:44
+	//
+	// ✘ // got = ctx.Value(key 2)		--- @ ./context_with_value_test.go:45
+	//     ✘ /* got */ 42 == /* want */ 43		--- @ ./context_with_value_test.go:45
+}
+
+func ExampleContextWithValue_ng_by_type() {
+	ctx := context.Background()
+
+	type key string
+	var k1 key = "key 1"
+	var v1 string = "value 1"
+
+	var k2 key = "key 2"
+	var v2 int = 42
+
+	ctx = context.WithValue(ctx, k1, v1)
+	ctx = context.WithValue(ctx, k2, v2)
+
+	its.ContextWithValue(k2, its.EqEq("value 1")).Match(ctx).OrError(t)
+	its.ContextWithValue(k1, its.EqEq(42)).Match(ctx).OrError(t)
+
+	// Output:
+	// ✘ // got = ctx.Value(key 2)		--- @ ./context_with_value_test.go:68
+	//     ✘ /* got */ 42 is not string
+	//
+	// ✘ // got = ctx.Value(key 1)		--- @ ./context_with_value_test.go:69
+	//     ✘ /* got */ value 1 is not int
+}
+
+func ExampleContextWithValue_ng_by_nil_context() {
+	var ctx context.Context = nil
+
+	type key string
+	var k1 key = "key 1"
+	its.ContextWithValue(k1, its.Always[any]()).Match(ctx).OrError(t)
+
+	// Output:
+	// ✘ // given context.Context is nil		--- @ ./context_with_value_test.go:84
+}


### PR DESCRIPTION
## About This PR

Add `context.Context` related Matchers.

- `its.Context`: alias of `its.Always[context.Context]`.
  - may be useful with mock.
- `its.ContextWithValue`: tests with `context.Context.Value`

## Related Issues

closes #88 .