### PR TITLE
Release/v0.6.2

### DIFF
--- a/cmp_eq.go
+++ b/cmp_eq.go
@@ -1,0 +1,20 @@
+package its
+
+import "github.com/youta-t/its/itskit"
+
+// CmpEq tests with
+//
+//	got.Cmp(want) == 0
+//
+// want value can be big.Int, for example, but whatever okay if it has Cmp().
+func CmpEq[T interface{ Cmp(T) int }](want T) itskit.Matcher[T] {
+	cancel := itskit.SkipStack()
+	defer cancel()
+	return itskit.SimpleMatcher(
+		func(got T) bool {
+			return got.Cmp(want) == 0
+		},
+		"(%v).Cmp(%v) == 0",
+		itskit.Got, itskit.Want(want),
+	)
+}

--- a/cmp_eq_test.go
+++ b/cmp_eq_test.go
@@ -1,0 +1,22 @@
+package its_test
+
+import (
+	"math/big"
+
+	"github.com/youta-t/its"
+)
+
+func ExampleCmpEq_ok() {
+	want := big.NewInt(42)
+	got := big.NewInt(42)
+	its.CmpEq(want).Match(got).OrError(t)
+	// Output:
+}
+
+func ExampleCmpEq_ng() {
+	want := big.NewInt(42)
+	got := big.NewInt(43)
+	its.CmpEq(want).Match(got).OrError(t)
+	// Output:
+	// ✘ (/* got */ 43).Cmp(/* want */ 42) == 0		--- @ ./cmp_eq_test.go:19
+}

--- a/cmp_greater_eq.go
+++ b/cmp_greater_eq.go
@@ -1,0 +1,22 @@
+package its
+
+import (
+	"github.com/youta-t/its/itskit"
+)
+
+// CmpGreaterEq tests with
+//
+//	got.Cmp(want) >= 0
+//
+// want value can be big.Int, for example, but whatever okay if it has Cmp().
+func CmpGreaterEq[T interface{ Cmp(T) int }](want T) itskit.Matcher[T] {
+	cancel := itskit.SkipStack()
+	defer cancel()
+	return itskit.SimpleMatcher(
+		func(got T) bool {
+			return got.Cmp(want) >= 0
+		},
+		"(%v).Cmp(%v) >= 0",
+		itskit.Got, itskit.Want(want),
+	)
+}

--- a/cmp_greater_eq_test.go
+++ b/cmp_greater_eq_test.go
@@ -1,0 +1,29 @@
+package its_test
+
+import (
+	"math/big"
+
+	"github.com/youta-t/its"
+)
+
+func ExampleCmpGreaterEq_ok_equal() {
+	want := big.NewInt(42)
+	got := big.NewInt(42)
+	its.CmpGreaterEq(want).Match(got).OrError(t)
+	// Output:
+}
+
+func ExampleCmpGreaterEq_ok_greater() {
+	want := big.NewInt(42)
+	got := big.NewInt(43)
+	its.CmpGreaterEq(want).Match(got).OrError(t)
+	// Output:
+}
+
+func ExampleCmpGreaterEq_ng() {
+	want := big.NewInt(42)
+	got := big.NewInt(41)
+	its.CmpGreaterEq(want).Match(got).OrError(t)
+	// Output:
+	// ✘ (/* got */ 41).Cmp(/* want */ 42) >= 0		--- @ ./cmp_greater_eq_test.go:26
+}

--- a/cmp_greater_than.go
+++ b/cmp_greater_than.go
@@ -1,0 +1,22 @@
+package its
+
+import (
+	"github.com/youta-t/its/itskit"
+)
+
+// CmpGreaterThan tests with
+//
+//	want.Cmp(got) > 0
+//
+// want value can be big.Int, for example, but whatever okay if it has Cmp().
+func CmpGreaterThan[T interface{ Cmp(T) int }](want T) itskit.Matcher[T] {
+	cancel := itskit.SkipStack()
+	defer cancel()
+	return itskit.SimpleMatcher(
+		func(got T) bool {
+			return got.Cmp(want) > 0
+		},
+		"(%v).Cmp(%v) > 0",
+		itskit.Got, itskit.Want(want),
+	)
+}

--- a/cmp_greater_than_test.go
+++ b/cmp_greater_than_test.go
@@ -1,0 +1,21 @@
+package its_test
+
+import (
+	"math/big"
+
+	"github.com/youta-t/its"
+)
+
+func ExampleCmpGreaterThan_ok() {
+	want := big.NewInt(42)
+	got := big.NewInt(43)
+	its.CmpGreaterThan(want).Match(got).OrError(t)
+	// Output:
+}
+func ExampleCmpGreaterThan_ng() {
+	want := big.NewInt(42)
+	got := big.NewInt(41)
+	its.CmpGreaterThan(want).Match(got).OrError(t)
+	// Output:
+	// ✘ (/* got */ 41).Cmp(/* want */ 42) > 0		--- @ ./cmp_greater_than_test.go:18
+}

--- a/cmp_lesser_eq.go
+++ b/cmp_lesser_eq.go
@@ -1,0 +1,22 @@
+package its
+
+import (
+	"github.com/youta-t/its/itskit"
+)
+
+// CmpLesserEq tests with
+//
+//	got.Cmp(want) <= 0
+//
+// want value can be big.Int, for example, but whatever okay if it has Cmp().
+func CmpLesserEq[T interface{ Cmp(T) int }](want T) itskit.Matcher[T] {
+	cancel := itskit.SkipStack()
+	defer cancel()
+	return itskit.SimpleMatcher(
+		func(got T) bool {
+			return got.Cmp(want) <= 0
+		},
+		"(%v).Cmp(%v) <= 0",
+		itskit.Got, itskit.Want(want),
+	)
+}

--- a/cmp_lesser_eq_test.go
+++ b/cmp_lesser_eq_test.go
@@ -1,0 +1,29 @@
+package its_test
+
+import (
+	"math/big"
+
+	"github.com/youta-t/its"
+)
+
+func ExampleCmpLesserEq_ok_equal() {
+	want := big.NewInt(42)
+	got := big.NewInt(42)
+	its.CmpLesserEq(want).Match(got).OrError(t)
+	// Output:
+}
+
+func ExampleCmpLesserEq_ok_lesser() {
+	want := big.NewInt(42)
+	got := big.NewInt(41)
+	its.CmpLesserEq(want).Match(got).OrError(t)
+	// Output:
+}
+
+func ExampleCmpLesserEq_ng() {
+	want := big.NewInt(42)
+	got := big.NewInt(43)
+	its.CmpLesserEq(want).Match(got).OrError(t)
+	// Output:
+	// ✘ (/* got */ 43).Cmp(/* want */ 42) <= 0		--- @ ./cmp_lesser_eq_test.go:26
+}

--- a/cmp_lesser_than.go
+++ b/cmp_lesser_than.go
@@ -1,0 +1,22 @@
+package its
+
+import (
+	"github.com/youta-t/its/itskit"
+)
+
+// CmpLesserThan tests with
+//
+//	got.Cmp(want) < 0
+//
+// want value can be big.Int, for example, but whatever okay if it has Cmp().
+func CmpLesserThan[T interface{ Cmp(T) int }](want T) itskit.Matcher[T] {
+	cancel := itskit.SkipStack()
+	defer cancel()
+	return itskit.SimpleMatcher(
+		func(got T) bool {
+			return got.Cmp(want) < 0
+		},
+		"(%v).Cmp(%v) < 0",
+		itskit.Got, itskit.Want(want),
+	)
+}

--- a/cmp_lesser_than_test.go
+++ b/cmp_lesser_than_test.go
@@ -1,0 +1,22 @@
+package its_test
+
+import (
+	"math/big"
+
+	"github.com/youta-t/its"
+)
+
+func ExampleCmpLesserThan_ok() {
+	want := big.NewInt(42)
+	got := big.NewInt(41)
+	its.CmpLesserThan(want).Match(got).OrError(t)
+	// Output:
+}
+
+func ExampleCmpLesserThan_ng() {
+	want := big.NewInt(42)
+	got := big.NewInt(43)
+	its.CmpLesserThan(want).Match(got).OrError(t)
+	// Output:
+	// ✘ (/* got */ 43).Cmp(/* want */ 42) < 0		--- @ ./cmp_lesser_than_test.go:19
+}


### PR DESCRIPTION
Add new matchers:

- `its.CmpEq`
- `its.CmpLesserThan`
- `its.CmpLesserEq`
- `its.CmpGreaterThan`
- `its.CmpGreaterEq`

These all are for  comparison with`.Cmp`, like `big.Int`.